### PR TITLE
fix: disable the profiler and debugger to fix issue

### DIFF
--- a/online-boutique-demo/release/kubernetes-manifests.yaml
+++ b/online-boutique-demo/release/kubernetes-manifests.yaml
@@ -112,12 +112,12 @@ spec:
             value: "currencyservice:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice:7070"
-          # - name: DISABLE_STATS
-          #   value: "1"
+          - name: DISABLE_STATS
+            value: "1"
           # - name: DISABLE_TRACING
           #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           - name: JAEGER_SERVICE_ADDR
             value: "host.docker.internal:14268"
           resources:
@@ -176,10 +176,10 @@ spec:
           value: "productcatalogservice:3550"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         resources:
           requests:
             cpu: 100m
@@ -261,8 +261,8 @@ spec:
           #   value: "aws"
           # - name: DISABLE_TRACING
           #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           - name: JAEGER_SERVICE_ADDR
             value: "host.docker.internal:14268"
           # - name: CYMBAL_BRANDING
@@ -324,6 +324,10 @@ spec:
         env:
         - name: PORT
           value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
@@ -378,8 +382,10 @@ spec:
         #   value: "1"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         - name: JAEGER_SERVICE_ADDR
           value: "host.docker.internal:14268"
         readinessProbe:
@@ -539,10 +545,10 @@ spec:
           value: "7000"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
@@ -594,10 +600,10 @@ spec:
           value: "50051"
         # - name: DISABLE_STATS
         #   value: "1"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
         - name: JAEGER_SERVICE_ADDR
           value: "host.docker.internal:14268"
         readinessProbe:
@@ -704,10 +710,14 @@ spec:
         env:
         - name: PORT
           value: "9555"
-        # - name: DISABLE_STATS
-        #   value: "1"
+        - name: DISABLE_STATS
+          value: "1"
         # - name: DISABLE_TRACING
         #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         - name: JAEGER_SERVICE_ADDR
           value: "host.docker.internal:14268"
         resources:


### PR DESCRIPTION
Currently, the online boutique is not coming up as described here - https://github.com/hypertrace/hypertrace/issues/342

The cause is behind we see this error log in the services:
```
To learn more about authentication and Google APIs, visit: 
https://cloud.google.com/docs/authentication/getting-started
/usr/src/app/node_modules/@google-cloud/profiler/build/src/index.js:120
        throw new Error('Project ID must be specified in the configuration');
```

As suggested - https://github.com/GoogleCloudPlatform/microservices-demo/pull/665#issue-1082546512 - one of the way to disable debugger and profile which needs PROJECT_ID. As part of this PR, fixing this.
